### PR TITLE
fix APK command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.7.1-alpine3.11
 
-RUN apk update && apk add build-base git nodejs python2 postgresql-dev postgresql-client graphicsmagick --no-cache yarn
+RUN apk update && apk add build-base git nodejs python2 postgresql-dev postgresql-client graphicsmagick yarn --no-cache
 
 # Make busybox and pry work nicely for large output
 ENV PAGER='more'


### PR DESCRIPTION
In the Dockerfile the `--no-cache` argument was given before the `yarn` argument. As a result the yarn package wasn't being installed in the container.