### PR TITLE
Properly test subscription swapping

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,7 +28,7 @@ class ApplicationController < ActionController::Base
     # Users are always allowed to manage their session, registration and subscription
     def access_required?
       user_signed_in? &&
-        !current_user.on_trial_or_subscribed_to_any? &&
+        !current_user.sub_active_or_trialing? &&
         !devise_controller? &&
         controller_name != "subscriptions"
     end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -22,6 +22,10 @@ class SubscriptionsController < ApplicationController
     current_user.processor = "stripe"
     success = if params[:plan_id].present?
       stripe_plan_id = Plan.find(params[:plan_id]).try(:stripe_id)
+      current_user.card_token ||= params[:payment_method_id]
+      # NOTE This shouldn't be needed but is.
+      # https://github.com/pay-rails/pay/issues/235
+      current_user.customer.invoice_settings
       current_user.sub.swap(stripe_plan_id)
       current_user.update(plan_id: params[:plan_id])
     elsif params[:payment_method_id].present?

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -8,8 +8,9 @@ class SubscriptionsController < ApplicationController
 
   # GET '/billing'
   def show
-    @plans = Plan.active.all.select(:id, :name)
     redirect_to subscribe_path unless current_user.sub_active?
+
+    @plans = Plan.active.all.select(:id, :name)
   end
 
   # GET '/subscribe'
@@ -22,10 +23,6 @@ class SubscriptionsController < ApplicationController
     current_user.processor = "stripe"
     success = if params[:plan_id].present?
       stripe_plan_id = Plan.find(params[:plan_id]).try(:stripe_id)
-      current_user.card_token ||= params[:payment_method_id]
-      # NOTE This shouldn't be needed but is.
-      # https://github.com/pay-rails/pay/issues/235
-      current_user.customer.invoice_settings
       current_user.sub.swap(stripe_plan_id)
       current_user.update(plan_id: params[:plan_id])
     elsif params[:payment_method_id].present?

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -9,12 +9,12 @@ class SubscriptionsController < ApplicationController
   # GET '/billing'
   def show
     @plans = Plan.active.all.select(:id, :name)
-    redirect_to subscribe_path unless current_user.subscribed_to_any?
+    redirect_to subscribe_path unless current_user.sub_active?
   end
 
   # GET '/subscribe'
   def new
-    redirect_to billing_path if current_user.subscribed_to_any?
+    redirect_to billing_path if current_user.sub_active?
   end
 
   # PATCH /subscriptions
@@ -22,7 +22,7 @@ class SubscriptionsController < ApplicationController
     current_user.processor = "stripe"
     success = if params[:plan_id].present?
       stripe_plan_id = Plan.find(params[:plan_id]).try(:stripe_id)
-      current_user.get_subscription.swap(stripe_plan_id)
+      current_user.sub.swap(stripe_plan_id)
       current_user.update(plan_id: params[:plan_id])
     elsif params[:payment_method_id].present?
       current_user.update_card(params[:payment_method_id])

--- a/app/models/plan.rb
+++ b/app/models/plan.rb
@@ -5,6 +5,7 @@
 class Plan < ApplicationRecord
   include CurrencyHelper
   belongs_to :product
+
   validates :name, presence: true
   validates :amount, presence: true
   validates :currency, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,22 +32,16 @@ class User < ApplicationRecord
   end
 
   # Assumes user has just one subscription
-  def get_subscription
-    Product.find_each.map(&:name).each do |product_name|
-      return subscription(name: product_name)
-    end
+  def sub
+    subscriptions.first
   end
 
-  def subscribed_to_any?
-    Product.find_each.map(&:name).each do |product_name|
-      return true if subscribed?(name: product_name)
-    end
-    false
+  def sub_active?
+    sub.status == "active"
   end
 
-  def on_trial_or_subscribed_to_any?
-    return true if on_trial?
-    subscribed_to_any?
+  def sub_active_or_trialing?
+    sub.status.in? ["active", "trialing"]
   end
 
   private

--- a/app/services/subscription_service.rb
+++ b/app/services/subscription_service.rb
@@ -38,18 +38,14 @@ class SubscriptionService
         yield if block
         stripe_success = true
       # https://stripe.com/docs/api?lang=ruby#errors
-      rescue Stripe::CardError => e
-        StripeLogger.error(e.json_body[:error])
-      rescue Stripe::RateLimitError
-        StripeLogger.error "Too many requests made to the API too quickly."
-      rescue Stripe::InvalidRequestError
-        StripeLogger.error "Invalid parameters were supplied to Stripe's API."
-      rescue Stripe::AuthenticationError
-        StripeLogger.error("Authentication with Stripe's API failed. Maybe you changed API keys recently. sdfgdfg")
-      rescue Stripe::APIConnectionError
-        StripeLogger.error "Network communication with Stripe failed."
-      rescue Stripe::StripeError
-        StripeLogger.error "Genric Stripe error."
+      rescue  Stripe::CardError,
+              Stripe::InvalidRequestError,
+              Stripe::RateLimitError,
+              Stripe::InvalidRequestError,
+              Stripe::AuthenticationError,
+              Stripe::APIConnectionError,
+              Stripe::StripeError => e
+        StripeLogger.error(e.json_body.try(:[], :error))
       end
       stripe_success
     end

--- a/app/services/subscription_service.rb
+++ b/app/services/subscription_service.rb
@@ -27,7 +27,7 @@ class SubscriptionService
 
   def destroy_subscription
     stripe_call do
-      @user.subscription.cancel
+      @user.sub.cancel
     end
   end
 

--- a/app/views/layouts/_navbar_loggedin.haml
+++ b/app/views/layouts/_navbar_loggedin.haml
@@ -16,7 +16,7 @@
             - if current_user.admin?
               = link_to "Admin", admin_root_path, class: "dropdown-item"
             - else
-              = current_user.subscribed_to_any? ? link_to("Billing", billing_path, class: "dropdown-item") : link_to("Subscribe ", subscribe_path, class: "dropdown-item")
+              = current_user.sub_active? ? link_to("Billing", billing_path, class: "dropdown-item") : link_to("Subscribe ", subscribe_path, class: "dropdown-item")
             .dropdown-divider
             = link_to "Stop Impersonating", admin_stop_impersonating_path, class: "dropdown-item" if current_user != true_user
             = link_to "Logout", main_app.destroy_user_session_path, class: "dropdown-item"

--- a/spec/factories/subscriptions.rb
+++ b/spec/factories/subscriptions.rb
@@ -9,8 +9,8 @@ FactoryBot.define do
     processor_id { "sub_xxx" }
     processor_plan { "plan_xxx" }
     quantity { 1 }
-    trial_ends_at { TRIAL_PERIOD_DAYS.days.from_now }
-    ends_at { nil }
+    trial_ends_at { nil }
+    ends_at { 30.days.from_now }
     created_at { 1.minute.ago }
     updated_at { 1.minute.ago }
     status { "active" }
@@ -46,6 +46,11 @@ FactoryBot.define do
 
     trait :trialing do
       status { "trialing" }
+      trial_ends_at { TRIAL_PERIOD_DAYS.days.from_now }
+    end
+    trait :trial_expired do
+      status { "trialing" }
+      trial_ends_at { 1.hour.ago }
     end
     trait :past_due do
       status { "past_due" }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -12,6 +12,11 @@ FactoryBot.define do
     association :plan
     initialize_with { User.where(email: email).first_or_initialize }
 
+    after(:create) do |user|
+      user.processor = "stripe"
+      user.subscribe(name: user.product.name, plan: user.plan.stripe_id)
+    end
+
     trait :admin do
       admin { true }
     end
@@ -22,6 +27,32 @@ FactoryBot.define do
 
     trait :trial_expired do
       trial_ends_at { 1.hour.ago }
+    end
+
+    trait :subscribed do
+      card_last4 { "4242" }
+      card_type { "Visa" }
+      card_exp_month { "06" }
+      card_exp_year { "2025" }
+      trial_ends_at { nil }
+
+      after(:create) do |user|
+        # NOTE this breaks swapping
+        user.subscriptions.first.update(
+          status: "active",
+          trial_ends_at: nil,
+          ends_at: 30.days.from_now
+        )
+        user.card_token = Stripe::PaymentMethod.create({
+          type: "card",
+            card: {
+              number: "4242424242424242",
+              exp_month: 6,
+              exp_year: 2025,
+              cvc: "123",
+            },
+          }).id
+      end
     end
 
     trait :avatared do

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe SubscriptionsController, type: :request do
 
   before do
     user_subscribed.processor = "stripe"
-    stripe_plan = Stripe::Plan.retrieve(plan.stripe_id)
   end
 
   describe "GET billing_path" do

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -58,7 +58,8 @@ RSpec.describe SubscriptionsController, type: :request do
     before { sign_in user }
     subject do
       patch subscriptions_path, params: {
-        plan_id: plan_pro.id
+        plan_id: plan_pro.id,
+        payment_method_id: payment_method.id
       }
     end
 
@@ -81,7 +82,8 @@ RSpec.describe SubscriptionsController, type: :request do
     before { sign_in user }
     subject do
       patch subscriptions_path, params: {
-        plan_id: plan_annual.id
+        plan_id: plan_annual.id,
+        payment_method_id: payment_method.id
       }
     end
 

--- a/spec/requests/subscriptions_spec.rb
+++ b/spec/requests/subscriptions_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SubscriptionsController, type: :request do
   let(:plan_pro) { create(:plan, :pro_monthly, product: product_pro) }
 
   let(:user_trial) { create(:user) }
-  let(:user_subscribed) { create(:user, :trial_expired) }
+  let(:user_subscribed) { create(:user, :subscribed) }
 
   let(:payment_method) do
     Stripe::PaymentMethod.create({
@@ -28,9 +28,6 @@ RSpec.describe SubscriptionsController, type: :request do
   before do
     user_subscribed.processor = "stripe"
     stripe_plan = Stripe::Plan.retrieve(plan.stripe_id)
-    # NOTE We don't need a card token here because the plan has a trial.
-    # If plan has no trial, then a card token is required.
-    user_subscribed.subscribe(name: product.name, plan: stripe_plan.id)
   end
 
   describe "GET billing_path" do
@@ -54,6 +51,52 @@ RSpec.describe SubscriptionsController, type: :request do
         expect(subject).to have_http_status(:success)
         expect(subject).to render_template "subscriptions/show"
       end
+    end
+  end
+
+  shared_examples_for "swap product" do
+    before { sign_in user }
+    subject do
+      patch subscriptions_path, params: {
+        plan_id: plan_pro.id
+      }
+    end
+
+    it "swaps the product and the plan" do
+      expect(user.sub.processor_plan).to eq plan.stripe_id
+      stripe_subscription = Stripe::Subscription.retrieve(user.sub.processor_id)
+      expect(stripe_subscription.plan.product).to eq product.stripe_id
+
+      expect(subject).to redirect_to billing_path
+
+      stripe_subscription = Stripe::Subscription.retrieve(user.sub.processor_id)
+      expect(stripe_subscription.plan.product).to eq product_pro.stripe_id
+      expect(flash[:success]).to match "Subscription updated"
+      expect(user.sub.processor_plan).to eq plan_pro.stripe_id
+      expect(user.plan_id).to eq plan_pro.id
+    end
+  end
+
+  shared_examples_for "swap plan" do
+    before { sign_in user }
+    subject do
+      patch subscriptions_path, params: {
+        plan_id: plan_annual.id
+      }
+    end
+
+    it "swaps the plan and keeps the product" do
+      expect(user.sub.processor_plan).to eq plan.stripe_id
+      stripe_subscription = Stripe::Subscription.retrieve(user.sub.processor_id)
+      expect(stripe_subscription.plan.product).to eq product.stripe_id
+
+      expect(subject).to redirect_to billing_path
+
+      stripe_subscription = Stripe::Subscription.retrieve(user.sub.processor_id)
+      expect(stripe_subscription.plan.product).to eq product.stripe_id
+      expect(flash[:success]).to match "Subscription updated"
+      expect(user.sub.processor_plan).to eq plan_annual.stripe_id
+      expect(user.plan_id).to eq plan_annual.id
     end
   end
 
@@ -83,50 +126,16 @@ RSpec.describe SubscriptionsController, type: :request do
       end
     end
 
-    context "swap products" do
-      before { sign_in user_subscribed }
-      subject do
-        patch subscriptions_path, params: {
-          plan_id: plan_pro.id
-        }
-      end
-
-      it "swaps the product and plan" do
-        expect(user_subscribed.get_subscription.processor_plan).to eq plan.stripe_id
-        stripe_subscription = Stripe::Subscription.retrieve(user_subscribed.get_subscription.processor_id)
-        expect(stripe_subscription.plan.product).to eq product.stripe_id
-
-        expect(subject).to redirect_to billing_path
-
-        stripe_subscription = Stripe::Subscription.retrieve(user_subscribed.get_subscription.processor_id)
-        expect(stripe_subscription.plan.product).to eq product_pro.stripe_id
-        expect(flash[:success]).to match "Subscription updated"
-        expect(user_subscribed.get_subscription.processor_plan).to eq plan_pro.stripe_id
-        expect(user_subscribed.plan_id).to eq plan_pro.id
-      end
+    context "as a trial user" do
+      let(:user) { user_trial }
+      it_should_behave_like "swap product"
+      it_should_behave_like "swap plan"
     end
 
-    context "swap plans" do
-      before { sign_in user_subscribed }
-      subject do
-        patch subscriptions_path, params: {
-          plan_id: plan_annual.id
-        }
-      end
-
-      it "swaps the plan and keeps the product" do
-        expect(user_subscribed.get_subscription.processor_plan).to eq plan.stripe_id
-        stripe_subscription = Stripe::Subscription.retrieve(user_subscribed.get_subscription.processor_id)
-        expect(stripe_subscription.plan.product).to eq product.stripe_id
-
-        expect(subject).to redirect_to billing_path
-
-        stripe_subscription = Stripe::Subscription.retrieve(user_subscribed.get_subscription.processor_id)
-        expect(stripe_subscription.plan.product).to eq product.stripe_id
-        expect(flash[:success]).to match "Subscription updated"
-        expect(user_subscribed.get_subscription.processor_plan).to eq plan_annual.stripe_id
-        expect(user_subscribed.plan_id).to eq plan_annual.id
-      end
+    context "as an active subscribed user" do
+      let(:user) { user_subscribed }
+      it_should_behave_like "swap product"
+      it_should_behave_like "swap plan"
     end
   end
 end

--- a/spec/requests/users/users_registrations_spec.rb
+++ b/spec/requests/users/users_registrations_spec.rb
@@ -31,10 +31,9 @@ RSpec.describe Users::RegistrationsController, type: :request do
       it "creates a user on a trial" do
         subject
         expect(user).to be_present
-        expect(user.on_trial_or_subscribed?).to be true
-        expect(user.on_trial?).to be true
         # NOTE User has a subscription but no payment source
-        expect(user.subscribed_to_any?).to be true
+        expect(user.sub_active_or_trialing?).to be true
+        expect(user.sub_active?).to be false
       end
 
       it "populates customer data" do
@@ -85,8 +84,9 @@ RSpec.describe Users::RegistrationsController, type: :request do
     let!(:user) { create(:user) }
     let(:subscription) { double(Pay::Subscription) }
     before do
-      allow(user).to receive(:subscription) { subscription }
+      allow(user).to receive(:sub) { subscription }
       allow(subscription).to receive(:cancel) { true }
+      allow(subscription).to receive(:status) { "trialing" }
       sign_in user
     end
     subject do
@@ -95,7 +95,7 @@ RSpec.describe Users::RegistrationsController, type: :request do
     end
 
     context "subscription cancellation succeeds" do
-      it "cancels the subscription, and signs out + discards the user" do
+      it "cancels the subscription" do
         expect(subscription).to receive(:cancel).once
         subject
       end


### PR DESCRIPTION
Odd behaviour was found when testing swapping on an active subscription in an app based on Limestone. Turned out to be due to factory setup. We now test swapping both plans (prices) and products on both trialing and subscribed contexts.