### PR TITLE
add missing semicolon to `import` in application.scss

### DIFF
--- a/app/javascript/packs/src/application.scss
+++ b/app/javascript/packs/src/application.scss
@@ -6,4 +6,4 @@ $fa-font-path: "~font-awesome/fonts";
 @import '../../../assets/stylesheets/avatars';
 @import '../../../assets/stylesheets/modals';
 @import '../../../assets/stylesheets/alerts';
-@import '../../../assets/stylesheets/stripe'
+@import '../../../assets/stylesheets/stripe';


### PR DESCRIPTION
Webpack builds without the semicolon ... but sometimes I see an error in my IDE.