### PR TITLE
Update to a non-yanked version of mimemagic

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -212,7 +212,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)


### PR DESCRIPTION
Several versions of mimemagic were yanked due to a licensing issue which subsequently broke half of the internet including this project. This PR should fix that issue.